### PR TITLE
Fix: end of line

### DIFF
--- a/modules/20-arithmetics/10-basics/ru/README.md
+++ b/modules/20-arithmetics/10-basics/ru/README.md
@@ -34,8 +34,8 @@ int main() {
 
 ```cpp
 int main() {
-  std::cout << 8 / 2;
-  std::cout << 3 * 3 * 3;
+  std::cout << 8 / 2 << std::endl;
+  std::cout << 3 * 3 * 3 << std::endl;
 }
 ```
 


### PR DESCRIPTION
Error at the end of the line after the numbers.
Without the end of the line it will be:
479
not:
4
79

p.s. The second end of line is not needed, but in exercises there is always a check for \n at the end.